### PR TITLE
Fix typos

### DIFF
--- a/docs/resources/server/restore.md
+++ b/docs/resources/server/restore.md
@@ -22,11 +22,11 @@ A typical Gauntlet Server response is structured with a `key:value:key:value` pa
 
 #### Official Level Structure
 
-There are three sections in regards to the `Official Level State` from the restore endpoint. The data is sent as `{NormalCompleted},{PracticeComepleted},{SecretCoins}`
+There are three sections in regards to the `Official Level State` from the restore endpoint. The data is sent as `{NormalCompleted},{PracticeCompleted},{SecretCoins}`
 
 > - `{NormalCompleted}` is a `Bool` which denotes if you have completed the level in normal Mode<br/><br/>
-> - `{PracticeComepleted}` is a `Bool` which denotes if you have completed the level in practice Mode<br/><br/>
-> - `{SecretCoins}` is an `Integer` which includes the ammount of Secret Coins you collected during the completion of the official level
+> - `{PracticeCompleted}` is a `Bool` which denotes if you have completed the level in practice Mode<br/><br/>
+> - `{SecretCoins}` is an `Integer` which includes the amount of Secret Coins you collected during the completion of the official level
 
 **<h4/>This structure is then iterated for each official level in the update and is split with a `;`**
 

--- a/docs/topics/tags.md
+++ b/docs/topics/tags.md
@@ -1,6 +1,6 @@
 # Tags
 
-> Various text interfaces within the Geometry Dash client can be manipulated using special tags similar to markup languages such as `HTML.` Geometry Dash has 3 primary types of tags
+> Various text interfaces within the Geometry Dash client can be manipulated using special tags similar to markup languages such as `HTML`. Geometry Dash has 3 primary types of tags
 
 - Colour Tags
 - Instant Tags


### PR DESCRIPTION
Also:
https://github.com/Wyliemaster/gddocs/blob/1e9c45e7170ab0af9722278b97dd97bec3631dc5/docs/resources/server/restore.md?plain=1#L31 there's `<h4/>` and `**` but only one of them is needed to make the text bold without changing font size. A change to that could be added to this PR.