### PR TITLE
Add Some Better Info about -6 being Also Related to Blacklisted Email Services.

### DIFF
--- a/docs/topics/status_codes.md
+++ b/docs/topics/status_codes.md
@@ -21,7 +21,7 @@ Events over the Geometry Dash servers usually send an error code denoting that t
 | `-3` | Email is in use | If an account with that already email exists |
 | `-4` | Username is invalid | If the username is invalid |
 | `-5` | Password is invalid | If the password is invalid |
-| `-6` | Email is invalid | If the email is invalid |
+| `-6` | Email is invalid | If the email is invalid or email sevice was blacklisted by Robtop |
 | `-7` | Passwords do not match | If the passwords don't match |
 | `-8` | Too short. Minimum 6 characters | If the password is less than 6 characters long |
 | `-9` | Too short. Minimum 3 characters | If the name is less than 3 characters long |


### PR DESCRIPTION
Thought it might be a smart idea to add some better info about why `-6` can occur since this has happened very recently with <b>mail.com</b> and <b>outlook.com</b> being blacklisted leading to a `-6` response from Robtop's servers. 