### PR TITLE
Fix loginGJAccount documentation.

### DIFF
--- a/docs/endpoints/accounts/loginGJAccount.md
+++ b/docs/endpoints/accounts/loginGJAccount.md
@@ -6,7 +6,7 @@
 
 | Parameter  | Explanation                                                                                           | Optional |
 | :--------- | :---------------------------------------------------------------------------------------------------- | :------- |
-| `udid`     | This isn't UDID but its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) instead.  | `False`  |
+| `udid`     | Funny enough, This isn't actually UDID but its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) instead.  | `False`  |
 | `userName` | The username for the account the player is trying to log into                                         | `False`  |
 | `password` | The plaintext password for the account the player is trying to log into                               | `False`  |
 | `sID`      | The player's steam ID                                                                                 | `True`   |

--- a/docs/endpoints/accounts/loginGJAccount.md
+++ b/docs/endpoints/accounts/loginGJAccount.md
@@ -6,8 +6,8 @@
 
 | Parameter  | Explanation                                                                                           | Optional |
 | :--------- | :---------------------------------------------------------------------------------------------------- | :------- |
-| `udid`     | [The user's Universal Unique Identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier) | `False`  |
-| `username` | The username for the account the player is trying to log into                                         | `False`  |
+| `udid`     | This isn't UDID but its [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) instead.  | `False`  |
+| `userName` | The username for the account the player is trying to log into                                         | `False`  |
 | `password` | The plaintext password for the account the player is trying to log into                               | `False`  |
 | `sID`      | The player's steam ID                                                                                 | `True`   |
 | `secret`   | Account Secret: `Wmfv3899gc9`                                                                         | `False`  |


### PR DESCRIPTION
The parameter is supposed to be `userName` and the UUID/UDID part is mixed up by RobTop to cause confusion.