### PR TITLE
Fix misleading hash information

### DIFF
--- a/docs/resources/server/hashes.md
+++ b/docs/resources/server/hashes.md
@@ -12,7 +12,6 @@ For each level, add these segments:
 - The last digit of the level ID
 - The stars the level awards
 - The amount of coins in the level
-- 0 if the level has unverified coins, 1 if verified
 
 Salt: `xI25fpAapCQg`
 

--- a/docs/resources/server/hashes.md
+++ b/docs/resources/server/hashes.md
@@ -11,7 +11,7 @@ For each level, add these segments:
 - The first digit of the level ID
 - The last digit of the level ID
 - The stars the level awards
-- The amount of coins in the level
+- 0 if the level has unverified coins, 1 if verified
 
 Salt: `xI25fpAapCQg`
 


### PR DESCRIPTION
This information is either misleading or just incorrect. I just confirmed this by generating the hash myself using a different method. It appears point 4 has been removed.
This is now the order:
- first ID digit
- last ID digit
- stars (18)
- verified coins (38)
