### PR TITLE
Inccorect shards in GS_Value.md and 2.2074 New

### DIFF
--- a/docs/resources/client/gamesave/GS_Value.md
+++ b/docs/resources/client/gamesave/GS_Value.md
@@ -21,10 +21,10 @@ GS values contain Information regarding certain aspects of the game
 | 13 | Total Diamonds |
 | 14 | current orbs |
 | 15 | Completed Daily Levels |
-| 16 | Fire Shards |
-| 17 | Ice Shards |
-| 18 | Poison Shards |
-| 19 | Shadow Shards |
+| 16 | Shadow Shards |
+| 17 | Poison Shards |
+| 18 | Fire Shards |
+| 19 | Ice Shards |
 | 20 | Lava Shards |
 | 21 | Demon Keys|
 | 22 | Total Orbs Collected |

--- a/docs/resources/client/gamesave/GS_Value.md
+++ b/docs/resources/client/gamesave/GS_Value.md
@@ -47,6 +47,8 @@ GS values contain Information regarding certain aspects of the game
 | 39 | Soul Path Progress |
 | 40 | Amount of Completed Gauntlets |
 | 41 | List Rewards |
+| 42 | Completed Insane Levels |
+| 43 | Wraith Chest Keys |
 | unique_{LevelID}_{Coins Collected} | The Coins Collected on the Official Levels
 | unique_secretB03 | Glubfub coin |
 | unique_secret04 | Official level page secret coin |


### PR DESCRIPTION
The shard values are incorrect

![image](https://github.com/user-attachments/assets/4eec6b25-6b48-4bf7-8a47-3db3773e3864)
![image](https://github.com/user-attachments/assets/bfcecbb5-d756-4130-b68c-5b764bb3a75b)
![image](https://github.com/user-attachments/assets/2fe7bac0-ad7d-47aa-8c74-a8321d9dddf0)

output got with this
```cpp
auto gsm = GameStatsManager::get();
for (int i = 0; i < 42; i++) 
    log::info("{0}. {1}", fmt::format("{}", i), gsm->getStat(fmt::format("{}", i).c_str()));
```